### PR TITLE
Simulacro examen Booking

### DIFF
--- a/BasePage.java
+++ b/BasePage.java
@@ -1,0 +1,39 @@
+package SimulacroExamen.Pages;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+import java.util.List;
+
+public class BasePage {
+
+    protected WebDriver driver;
+
+
+    public String getPageTitle(){
+        return driver.getTitle();
+    }
+
+    public String getPageURL(){
+        return driver.getCurrentUrl();
+    }
+
+    public void getAllLinks(){
+        List<WebElement> listaLinks = driver.findElements(By.tagName("a"));
+        for (WebElement links : listaLinks) {
+            System.out.println(links.getText());
+        }
+    }
+
+    public void getAllH1() {
+        //OBTENER ELEMENTOS h1
+        String elemento ;
+        List<WebElement> listaH1s = driver.findElements(By.tagName("h1"));
+
+        for (WebElement h1 : listaH1s) {
+            elemento =h1.getText();
+            System.out.println(elemento);
+        }
+    }
+}

--- a/DataProviderGenerator.java
+++ b/DataProviderGenerator.java
@@ -1,0 +1,16 @@
+package SimulacroExamen;
+
+import org.testng.annotations.DataProvider;
+
+public class DataProviderGenerator {
+    @DataProvider(name="passwords")
+    public Object [][] typeOfPassrords(){
+        return new Object[][]{
+                {"11","11","LONGITUD_INCORRECTA"},
+                {"4444444444","4444444444","FALTA_MAYUSCULA"},
+                {"AAAAAAAAAA","AAAAAAAAAA","FALTA_NUMERO"},
+                {"Test123456789","Test12345678900","NO_COINCIDEN"},
+                {"Test123456789","Test123456789","CORRECTO"}
+        };
+    }
+}

--- a/HomePageBooking.java
+++ b/HomePageBooking.java
@@ -1,0 +1,40 @@
+package SimulacroExamen.Pages;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+import java.util.List;
+
+public class HomePageBooking extends BasePage{
+
+    public HomePageBooking(WebDriver driver){
+        this.driver = driver;
+    }
+
+    public void acceptCookies(){
+        driver.findElement(By.id("onetrust-accept-btn-handler")).click();
+    }
+
+    public SignUpPage goToLogin(){
+        driver.findElement(By.linkText("Inicia sesión")).click();
+        SignUpPage nextpage = new SignUpPage(driver);
+        return nextpage;
+    }
+
+    public String getAllH2() {
+        //OBTENER ELEMENTOS h2
+        String textoBuscado="";
+        String elemento ;
+        List<WebElement> listaH2s = driver.findElements(By.tagName("h2"));
+
+        for (WebElement h2 : listaH2s) {
+            elemento =h2.getText();
+            if (elemento.contains("Conecta con gente viajera")){
+                textoBuscado = elemento;
+            }
+
+        }
+        return textoBuscado;
+    }
+}

--- a/PruebaBooking.java
+++ b/PruebaBooking.java
@@ -1,0 +1,70 @@
+package SimulacroExamen.Tests;
+
+import SimulacroExamen.DataProviderGenerator;
+import SimulacroExamen.Pages.HomePageBooking;
+import SimulacroExamen.Pages.RegisterPasswordPage;
+import SimulacroExamen.Pages.SignUpPage;
+import org.openqa.selenium.WebElement;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+public class PruebaBooking extends TestBase{
+
+    private SignUpPage signUpPage;
+    private RegisterPasswordPage registerPasswordPage;
+
+    @Test
+    public void validarTituloTest(){
+        Assert.assertEquals(homePageBooking.getPageTitle(),"Booking.com | Sitio oficial | Los mejores hoteles, vuelos, coches de alquiler y alojamientos");
+    }
+
+    @Test
+    public void mostarLinksTest(){
+       homePageBooking.getAllLinks();
+    }
+
+    @Test
+    public void mostarH1sTest(){
+        homePageBooking.getAllH1();
+    }
+
+    @Test
+    public void buscarGenteViajeraTest(){
+        String h2Encontrado= homePageBooking.getAllH2();
+        Assert.assertEquals(h2Encontrado,"Conecta con gente viajera");
+    }
+    @Test(dataProvider = "passwords", dataProviderClass = DataProviderGenerator.class)
+    public void validErrorMessagesPasswordTests(String password, String confirmedPassword, String scenario){
+        signUpPage= homePageBooking.goToLogin();
+        Assert.assertEquals(homePageBooking.getPageTitle(),"Booking.com");
+        signUpPage.mail();
+        registerPasswordPage= signUpPage.submitButton();
+        registerPasswordPage.setPassword(password);
+        registerPasswordPage.setConfirmPassword(confirmedPassword);
+        registerPasswordPage.createAccountButton();
+
+        List<WebElement> errors = registerPasswordPage.errorsPassword();
+        for(WebElement elemento : errors){
+            String texto= elemento.getText();
+            if(texto.contains("coinciden") && scenario.equals("NO_COINCIDEN")){
+                Assert.assertEquals(texto,"Las contraseñas no coinciden. Inténtalo de nuevo.");
+                System.out.println(texto);
+            }else if (texto.contains("10 caracteres") && scenario.equals("LONGITUD_INCORRECTA")){
+                Assert.assertEquals(texto,"La contraseña debe tener al menos 10 caracteres");
+                System.out.println(texto);
+            }else if (texto.contains("numero") && scenario.equals("FALTA_NUMERO")){
+                Assert.assertEquals(texto,"La contraseña debe incluir al menos un número");
+                System.out.println(texto);
+            }else if (texto.contains("mayúscula") && scenario.equals("FALTA_MAYUSCULA")){
+                Assert.assertEquals(texto,"La contraseña debe incluir al menos una letra en mayúscula");
+                System.out.println(texto);
+            }else if(scenario.equals("CORRECTO")){
+                System.out.println("Contraseña correcta");
+            }
+        }
+    }
+
+
+}

--- a/RegisterPasswordPage.java
+++ b/RegisterPasswordPage.java
@@ -1,0 +1,35 @@
+package SimulacroExamen.Pages;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+import java.util.List;
+
+public class RegisterPasswordPage extends BasePage{
+
+    public RegisterPasswordPage (WebDriver driver){
+        this.driver = driver;
+    }
+    public void setPassword(String password){
+        driver.findElement(By.id("new_password")).sendKeys(password);
+    }
+    public void setConfirmPassword(String confirmedPassword){
+        driver.findElement(By.id("confirmed_password")).sendKeys(confirmedPassword);
+    }
+
+    public List<WebElement> errorsPassword(){
+        //driver.findElement(By.id("new_password-note"));
+
+        List<WebElement> errores = driver.findElements(By.id("new_password-note"));
+
+        return errores;
+    }
+
+    public void createAccountButton(){
+        driver.findElement(By.xpath("//*[@type='submit']")).click();
+    }
+
+
+
+}

--- a/SignUpPage.java
+++ b/SignUpPage.java
@@ -1,0 +1,27 @@
+package SimulacroExamen.Pages;
+
+import com.github.javafaker.Faker;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+
+
+public class SignUpPage extends BasePage{
+    public Faker faker = new Faker();
+
+    public SignUpPage(WebDriver driver){
+        this.driver = driver;
+    }
+
+    public void mail (){
+        //en vez de usar un faker uso un correo inventado, ya que me he encontrado algun correo generado por faker dado de alta
+        //driver.findElement(By.id("username")).sendKeys(faker.internet().emailAddress());
+        driver.findElement(By.id("username")).sendKeys("testbookingprueba@gmail.com");
+    }
+    public RegisterPasswordPage submitButton(){
+        driver.findElement(By.xpath("//*[@type='submit']")).click();
+        RegisterPasswordPage nextpage = new RegisterPasswordPage(driver);
+        return nextpage;
+    }
+
+
+}

--- a/TestBase.java
+++ b/TestBase.java
@@ -1,0 +1,35 @@
+package SimulacroExamen.Tests;
+
+import SimulacroExamen.Pages.HomePageBooking;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+
+import java.util.concurrent.TimeUnit;
+
+public class TestBase {
+    WebDriver driver;
+    protected HomePageBooking homePageBooking;
+    private String url= "https://www.booking.com/";
+
+    @BeforeMethod
+    public void setup()throws InterruptedException{
+        System.setProperty("webdriver.chrome.driver","drivers/chromedriver.exe");
+        driver = new ChromeDriver();
+        driver.get(url);
+        homePageBooking = new HomePageBooking(driver);
+        driver.manage().window().maximize();
+         driver.manage().timeouts().implicitlyWait(30, TimeUnit.SECONDS);
+      //  Thread.sleep(2000);
+        //accept cookies
+        homePageBooking.acceptCookies();
+
+    }
+
+    @AfterMethod
+    public void driverClose(){
+        driver.close();
+    }
+}

--- a/testng.xml
+++ b/testng.xml
@@ -1,0 +1,8 @@
+<suite name = "simulacro examen ">
+    <test name = "pruebas booking ">
+        <classes>
+            <class name="SimulacroExamen.Tests.PruebaBooking">
+            </class>
+        </classes>
+    </test>
+</suite>


### PR DESCRIPTION
Se ha añadido dataProvider para validar las passwords, ya que actualmente la página tengas o no mail registrado permite dar de alta desde cualquier botón, bien sea desde inciar sesión o registrarse.

El faker en el mail está comentado, ya que me he encontrado con alguna cuenta generada ya dada de alta, por tanto uso un correo inventado. Resto de peticiones del ejercicio están puestos, ya que se podían sacar
La cuenta de test@test ya no salía dada de alta, por tanto no se ha creado test para ello